### PR TITLE
feat: make trailing newline stripping configurable

### DIFF
--- a/DankBitwarden.qml
+++ b/DankBitwarden.qml
@@ -217,7 +217,7 @@ QtObject {
         _prevPass = item._passId;
         Quickshell.execDetached([
             "sh", "-c",
-            "rbw get --field '" + field + "' '" + item._passId + "' | dms cl copy && sleep 0.3 && " +
+            "rbw get --field '" + field + "' '" + item._passId + "' | tr -d '\\n' | dms cl copy && sleep 0.3 && " +
             'dms cl delete $(dms cl history --json | awk \'/"id":/{print $2+0; exit}\')'
         ]);
         ToastService.showInfo("DankBitwarden", "Copied " + field + " of " + item._passName + " to clipboard");


### PR DESCRIPTION
## Summary

Adds a **Strip Trailing Newline** toggle (default on) and applies it consistently to autotype, type, and copy paths.

## Motivation

[`db08fba`](https://github.com/Pacman99/DankBitwarden/commit/db08fba) added `| tr -d '\n'` to the type/autotype paths but `copyItemField` was never updated. So copying a password/username/TOTP via the context menu left a trailing `0x0a` on the clipboard, which auto-submits the next form on paste — exactly the hazard the type-path fix was guarding against.

I almost shipped this as an unconditional fix on the copy path, but on reflection a single user-facing toggle that covers all three paths (autotype / type / copy) is more honest: it makes the behaviour explicit, lets anyone who actually wants a trailing newline opt out, and keeps the three exec paths symmetric.

## Behaviour

- Default ON. Current observable behaviour for autotype/type is preserved.
- Copy path now strips by default, closing the gap reported in #5.
- Toggle OFF → all three paths emit the raw `rbw --field` output, including its trailing newline.

## Test plan

Tested locally on Wayland with `dms ipc plugins reload dankBitwarden`:

- [x] Toggle visible in DMS launcher → DankBitwarden settings, default on.
- [x] Copy with toggle ON: `wl-paste | xxd | tail -1` → no `0a` byte.
- [x] Copy with toggle OFF: trailing `0a` reappears.
- [x] Autotype with toggle ON: cursor lands on password field, no Enter sent.
- [x] Autotype with toggle OFF: trailing newline reappears (form auto-submits).

Closes #5.