### PR TITLE
Add fuzzy matching for pass search

### DIFF
--- a/DankBitwarden.qml
+++ b/DankBitwarden.qml
@@ -3,6 +3,7 @@ import Quickshell
 import Quickshell.Io
 import qs.Common
 import qs.Services
+import "FuzzyMatcher.js" as FuzzyMatcher
 
 QtObject {
     id: root
@@ -122,9 +123,13 @@ QtObject {
 
         for (let i = 0; i < _passwords.length; i++) {
             const pass = _passwords[i];
-            const passLower = pass.name.toLowerCase();
+            const matchScore = FuzzyMatcher.scoreCandidate([
+                pass.name,
+                pass.user,
+                pass.folder
+            ], lowerQuery);
 
-            if (lowerQuery.length === 0 || passLower.includes(lowerQuery)) {
+            if (lowerQuery.length === 0 || matchScore >= 0) {
                 const meta = _metaFor(pass.type);
                 results.push({
                     name: (pass.folder != null ? pass.folder + "/" : "") + pass.name,
@@ -137,7 +142,8 @@ QtObject {
                     _passUser: pass.user,
                     _passFolder: pass.folder,
                     _passType: pass.type,
-                    _sortKey: pass.id == _prevPass ? 0 : 1
+                    _sortKey: pass.id == _prevPass ? 0 : 1,
+                    _fuzzyScore: matchScore
                 });
             }
         }
@@ -151,13 +157,15 @@ QtObject {
         };
 
         // Sync item should be sorted like any other item once typing starts
-         if (lowerQuery.length !== 0 && "sync".includes(lowerQuery)) {
+         if (lowerQuery.length !== 0 && FuzzyMatcher.scoreCandidate(["sync"], lowerQuery) >= 0) {
             results.push(syncItem);
         }
 
         results.sort((a, b) => {
             if (a._sortKey !== b._sortKey)
                 return a._sortKey - b._sortKey;
+            if (lowerQuery.length !== 0 && a._fuzzyScore !== b._fuzzyScore)
+                return a._fuzzyScore - b._fuzzyScore;
             return a._passName.localeCompare(b._passName);
         });
 

--- a/FuzzyMatcher.js
+++ b/FuzzyMatcher.js
@@ -1,0 +1,53 @@
+.pragma library
+
+function normalize(value) {
+    if (value === null || value === undefined)
+        return "";
+    return String(value).toLowerCase();
+}
+
+function scoreToken(field, token) {
+    if (token.length === 0)
+        return 0;
+
+    const text = normalize(field);
+    const directIndex = text.indexOf(token);
+    if (directIndex !== -1)
+        return directIndex;
+
+    let lastIndex = -1;
+    let gapPenalty = 0;
+
+    for (let i = 0; i < token.length; i++) {
+        const nextIndex = text.indexOf(token.charAt(i), lastIndex + 1);
+        if (nextIndex === -1)
+            return -1;
+        gapPenalty += nextIndex - lastIndex - 1;
+        lastIndex = nextIndex;
+    }
+
+    return 100 + gapPenalty + Math.max(0, text.length - token.length);
+}
+
+function scoreCandidate(fields, query) {
+    const trimmed = normalize(query).trim();
+    if (trimmed.length === 0)
+        return 0;
+
+    const tokens = trimmed.split(/\s+/);
+    let total = 0;
+
+    for (let i = 0; i < tokens.length; i++) {
+        let best = -1;
+        for (let j = 0; j < fields.length; j++) {
+            const score = scoreToken(fields[j], tokens[i]);
+            if (score >= 0 && (best === -1 || score < best))
+                best = score;
+        }
+        if (best === -1)
+            return -1;
+        total += best;
+    }
+
+    return total;
+}


### PR DESCRIPTION
Summary:
- add a small QML-compatible fuzzy matcher helper
- rank pass entries by name, user, and folder matches
- support multi-token queries while keeping the sync item available

Verification:
- git diff --check

Fixes #7

No payment expected upfront. If this PR is useful and gets merged, an optional tip/donation is appreciated so I can keep doing small maintainer-unblocking fixes.