### PR TITLE
feat: fuzzy + multi-token search across name, username, folder

### DIFF
--- a/DankBitwarden.qml
+++ b/DankBitwarden.qml
@@ -18,6 +18,7 @@ QtObject {
     property bool _loading: false
     property int _pendingLoads: 0
     property var _fieldsCache: ({})
+    property FuzzyMatcher _fuzzy: FuzzyMatcher {}
 
     readonly property var _typeMeta: ({
         "Login":    { icon: "material:password",    primary: "password",   base: ["username", "password", "totp"] },
@@ -62,6 +63,22 @@ QtObject {
 
     function _metaFor(type) {
         return _typeMeta[type] || { icon: "material:lock", primary: null, base: [] };
+    }
+
+    function _makeItem(pass) {
+        const meta = _metaFor(pass.type);
+        return {
+            name: (pass.folder != null ? pass.folder + "/" : "") + pass.name,
+            icon: meta.icon,
+            comment: pass.user,
+            action: "default:" + pass.id,
+            categories: ["Dank Bitwarden"],
+            _passName: pass.name,
+            _passId: pass.id,
+            _passUser: pass.user,
+            _passFolder: pass.folder,
+            _passType: pass.type
+        };
     }
 
     function _defaultActionForType(type) {
@@ -117,30 +134,9 @@ QtObject {
     }
 
     function getItems(query) {
-        const lowerQuery = query ? query.toLowerCase().trim() : "";
-        let results = [];
-
-        for (let i = 0; i < _passwords.length; i++) {
-            const pass = _passwords[i];
-            const passLower = pass.name.toLowerCase();
-
-            if (lowerQuery.length === 0 || passLower.includes(lowerQuery)) {
-                const meta = _metaFor(pass.type);
-                results.push({
-                    name: (pass.folder != null ? pass.folder + "/" : "") + pass.name,
-                    icon: meta.icon,
-                    comment: pass.user,
-                    action: "default:" + pass.id,
-                    categories: ["Dank Bitwarden"],
-                    _passName: pass.name,
-                    _passId: pass.id,
-                    _passUser: pass.user,
-                    _passFolder: pass.folder,
-                    _passType: pass.type,
-                    _sortKey: pass.id == _prevPass ? 0 : 1
-                });
-            }
-        }
+        // Cap length so a pasted blob can't make the per-keystroke fuzzy scan
+        // do unbounded work over a large vault.
+        const raw = (query ? query.toLowerCase().trim() : "").slice(0, 128);
 
         const syncItem = {
             name: "Sync",
@@ -150,23 +146,50 @@ QtObject {
             _passName: "sync"
         };
 
-        // Sync item should be sorted like any other item once typing starts
-         if (lowerQuery.length !== 0 && "sync".includes(lowerQuery)) {
-            results.push(syncItem);
-        }
+        let results = [];
 
-        results.sort((a, b) => {
-            if (a._sortKey !== b._sortKey)
-                return a._sortKey - b._sortKey;
-            return a._passName.localeCompare(b._passName);
-        });
-
-        // If length is zero then add sync item so user knows its an option.
-        // Insert it after the MRU entry (if present) so the previously-used
-        // entry stays at the very top.
-        if (lowerQuery.length === 0) {
+        if (raw.length === 0) {
+            for (let i = 0; i < _passwords.length; i++) {
+                const pass = _passwords[i];
+                const item = _makeItem(pass);
+                item._sortKey = pass.id == _prevPass ? 0 : 1;
+                results.push(item);
+            }
+            results.sort((a, b) => {
+                if (a._sortKey !== b._sortKey)
+                    return a._sortKey - b._sortKey;
+                return a._passName.localeCompare(b._passName);
+            });
+            // Keep the previously-used entry at the very top; sync sits just below it.
             const insertAt = (results.length > 0 && results[0]._sortKey === 0) ? 1 : 0;
             results.splice(insertAt, 0, syncItem);
+        } else {
+            // Fuzzy multi-token match across name, username and folder.
+            const tokens = raw.split(/\s+/).filter(t => t.length > 0);
+            for (let i = 0; i < _passwords.length; i++) {
+                const pass = _passwords[i];
+                const score = _fuzzy.matchAll(tokens, pass._search);
+                if (score === null)
+                    continue;
+                const item = _makeItem(pass);
+                item._score = score;
+                item._mru = pass.id == _prevPass;
+                results.push(item);
+            }
+            const syncScore = _fuzzy.matchAll(tokens, "sync");
+            if (syncScore !== null) {
+                syncItem._score = syncScore;
+                syncItem._mru = false;
+                results.push(syncItem);
+            }
+            // Rank by match quality; previously-used entry wins ties.
+            results.sort((a, b) => {
+                if (b._score !== a._score)
+                    return b._score - a._score;
+                if (a._mru !== b._mru)
+                    return a._mru ? -1 : 1;
+                return a._passName.localeCompare(b._passName);
+            });
         }
 
         const top = results.slice(0, 50);
@@ -263,6 +286,10 @@ QtObject {
     function onPasswordsLoaded(data) {
         if (!data?.length)
             return;
+        for (let i = 0; i < data.length; i++) {
+            const p = data[i];
+            p._search = (p.name + " " + (p.user || "") + " " + (p.folder || "")).toLowerCase();
+        }
         _passwords = data;
 
         _pendingLoads--;

--- a/FuzzyMatcher.qml
+++ b/FuzzyMatcher.qml
@@ -1,0 +1,105 @@
+import QtQuick
+
+// fzy-style subsequence scorer (algorithm: https://github.com/jhawthorn/fzy).
+// Pure functions, no state. Comparison is case-insensitive; callers pass
+// pre-lowercased haystacks. Higher score = better match.
+QtObject {
+    function isSubsequence(needle, hay) {
+        let j = 0;
+        for (let i = 0; i < hay.length && j < needle.length; i++) {
+            if (hay[i] === needle[j])
+                j++;
+        }
+        return j === needle.length;
+    }
+
+    // Per-character word-boundary bonus: a matched char scores higher right
+    // after a separator (path slash, space, dash/underscore, dot).
+    function _bonusArray(hay) {
+        const bonus = new Array(hay.length);
+        let prev = "/";
+        for (let j = 0; j < hay.length; j++) {
+            const ch = hay[j];
+            const alnum = (ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9");
+            if (!alnum)
+                bonus[j] = 0;
+            else if (prev === "/")
+                bonus[j] = 0.9;
+            else if (prev === "-" || prev === "_" || prev === " ")
+                bonus[j] = 0.8;
+            else if (prev === ".")
+                bonus[j] = 0.6;
+            else
+                bonus[j] = 0;
+            prev = ch;
+        }
+        return bonus;
+    }
+
+    // Best alignment score via fzy's two-row dynamic program. Assumes needle is
+    // a subsequence of hay (matchAll pre-checks); rewards consecutive runs and
+    // boundary hits, penalises gaps.
+    function _score(needle, hay, bonus) {
+        const n = needle.length;
+        const m = hay.length;
+        const GAP_LEADING = -0.005;
+        const GAP_INNER = -0.01;
+        const GAP_TRAILING = -0.005;
+        const CONSECUTIVE = 1.0;
+        const MIN = Number.NEGATIVE_INFINITY;
+
+        let prevD = new Array(m);
+        let prevM = new Array(m);
+        let currD = new Array(m);
+        let currM = new Array(m);
+
+        for (let i = 0; i < n; i++) {
+            let rowBest = MIN;
+            const gap = (i === n - 1) ? GAP_TRAILING : GAP_INNER;
+            for (let j = 0; j < m; j++) {
+                if (needle[i] === hay[j]) {
+                    let s = MIN;
+                    if (i === 0)
+                        s = j * GAP_LEADING + bonus[j];
+                    else if (j > 0)
+                        s = Math.max(prevM[j - 1] + bonus[j], prevD[j - 1] + CONSECUTIVE);
+                    currD[j] = s;
+                    rowBest = Math.max(s, rowBest + gap);
+                    currM[j] = rowBest;
+                } else {
+                    currD[j] = MIN;
+                    rowBest = rowBest + gap;
+                    currM[j] = rowBest;
+                }
+            }
+            const td = prevD; prevD = currD; currD = td;
+            const tm = prevM; prevM = currM; currM = tm;
+        }
+        return prevM[m - 1];
+    }
+
+    // Multi-token AND: every non-empty whitespace token must match hay as a
+    // subsequence. Returns the summed score, or null if any token misses or no
+    // usable token is given. Empty tokens are ignored (no score, no NaN).
+    function matchAll(tokens, hay) {
+        let matched = 0;
+        for (let i = 0; i < tokens.length; i++) {
+            const t = tokens[i];
+            if (t.length === 0)
+                continue;
+            if (!isSubsequence(t, hay))
+                return null;
+            matched++;
+        }
+        if (matched === 0)
+            return null;
+        const bonus = _bonusArray(hay);
+        let total = 0;
+        for (let i = 0; i < tokens.length; i++) {
+            const t = tokens[i];
+            if (t.length > 0)
+                total += _score(t, hay, bonus);
+        }
+        return total;
+    }
+}


### PR DESCRIPTION
Implements #7. Replaces the single-substring `name` match in `getItems`
with an fzy-style subsequence scorer.

Per the suggestion on the issue, the matcher lives in its own file
(`FuzzyMatcher.qml`) and is referenced from `getItems`.

## What
- `FuzzyMatcher.qml`: pure, stateless fzy-style scorer. Subsequence match
  with word-boundary / consecutive-run bonuses (algorithm:
  https://github.com/jhawthorn/fzy). `matchAll(tokens, hay)` ANDs the tokens
  and returns a summed score, or `null` if any token misses.
- `getItems`: splits the query on whitespace and fuzzy-matches each token
  against `name + username + folder` (a precomputed lowercased haystack),
  ranking by score with the previously-used entry as a tiebreaker. The
  empty-query view keeps the existing MRU/alpha ordering.

Covers A (subsequence fuzzy), B (multi-token AND) and D (match username and
folder) from the issue.

## Behavior
- Multi-term is AND and order-independent: `github main` is the same as
  `main github`.
- Each term is a fuzzy subsequence, so `gh ent` matches `GitHub Enterprise`.
- Case-insensitive; subsequence-based (no typo tolerance).
- Query length is capped before scoring to bound per-keystroke work.

## Out of scope
Match highlighting of fuzzy / multi-token results is not included. The
launcher owns highlighting (`_applyHighlights` / `_highlightField`) and
recomputes `_hName` per keystroke with a contiguous-substring highlighter,
so a plugin cannot supply fuzzy highlight markup. That would be a
DankMaterialShell change rather than a plugin one.
